### PR TITLE
Fix footer navigation links

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -47,9 +47,9 @@ export const Footer = () => {
             <ul className="space-y-3">
               {footerLinks.product.map((link) => (
                 <li key={link.href}>
-                  <a href={link.href} className="text-gray-400 hover:text-[#00c896] transition-colors duration-200">
+                  <Link to={link.href} className="text-gray-400 hover:text-[#00c896] transition-colors duration-200">
                     {link.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -61,9 +61,9 @@ export const Footer = () => {
             <ul className="space-y-3">
               {footerLinks.company.map((link) => (
                 <li key={link.href}>
-                  <a href={link.href} className="text-gray-400 hover:text-[#00c896] transition-colors duration-200">
+                  <Link to={link.href} className="text-gray-400 hover:text-[#00c896] transition-colors duration-200">
                     {link.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- use React Router `Link` in footer product and company sections so internal navigation no longer reloads the page

## Testing
- `CI=true npm test` *(fails: craco not found)*
- `npx @craco/craco test` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68a84c4dc28c8326af79403cd3ebb8e9